### PR TITLE
Add a better message before installation when the current folder is not writable

### DIFF
--- a/install.php
+++ b/install.php
@@ -9,6 +9,11 @@ ini_set('display_errors', 'On');
 
 include_once "inc/functions.php";
 
+if ( !is_writable(dirname(__FILE__)) ) {
+	printf('<strong>Erreur</strong> : le dossier <em>%s</em> n\'est pas accessible en écriture.', dirname(__FILE__));
+	exit;
+}
+
 $tpl = setRainTpl('tpl/', 'cache/tpl/');
 
 $serverConfig['phpVersion'] = PHP_VERSION;


### PR DESCRIPTION
C'est juste pour faire plus propre, chez moi je n'avais pas les bonnes permissions et me suis retrouvé avec une erreur et une exeception : 

```
Warning: mkdir() [function.mkdir]: Permission denied in /var/www/local/ddb-rev/inc/rain.tpl.class.php on line 318

Fatal error: Uncaught exception 'RainTpl_Exception' with message 'Cache directory cache/tpl/doesn't have write permission. Set write permission or set RAINTPL_CHECK_TEMPLATE_UPDATE to false. More details on http://www.raintpl.com/Documentation/Documentation-for-PHP-developers/Configuration/' in /var/www/local/ddb-rev/inc/rain.tpl.class.php:321 Stack trace: #0 /var/www/local/ddb-rev/inc/rain.tpl.class.php(274): RainTPL->compileFile('install', NULL, 'tpl/install.htm...', 'cache/tpl/', 'cache/tpl/insta...') #1 /var/www/local/ddb-rev/inc/rain.tpl.class.php(164): RainTPL->check_template('install') #2 /var/www/local/ddb-rev/install.php(184): RainTPL->draw('install') #3 {main} thrown in /var/www/local/ddb-rev/inc/rain.tpl.class.php on line 321
```
