### PR TITLE
[FIX] Install: enhance root rights check.

### DIFF
--- a/install.php
+++ b/install.php
@@ -8,6 +8,7 @@ include_once "inc/functions.php";
 
 $tpl_cache = 'cache/tpl/';
 if ( !is_writable(dirname(__FILE__)) ) {
+	$err = 1;
 	$tpl_cache = sys_get_temp_dir().'/DDb/';
 }
 $tpl = setRainTpl('tpl/', $tpl_cache);
@@ -23,6 +24,11 @@ $serverConfig['dbPermissions'] = is_writable($serverConfig['dbDirectory']);
 $serverOk = $serverConfig['phpIsVersionValid'] && $serverConfig['pdo'] &&
     $serverConfig['pdoSqlite'] && $serverConfig['dbPermissions'];
 
+// Check rigths
+if ( !file_exists("database.sqlite") && isset($err) ) {
+	$step = 1;
+	$tpl->assign( "serverConfig", $serverConfig );
+} else {
 //STEP 3: install done
 if(file_exists("database.sqlite")) {
     $step = 3;
@@ -173,6 +179,7 @@ if(!file_exists("database.sqlite") && isset($_GET['step']) && intval($_GET['step
     
     $tpl->assign( "serverConfig", $serverConfig );
     
+}
 }
 
 $tpl->assign( "noLogout", true );   //no DDb command button


### PR DESCRIPTION
Pour finir avec l'installation, j'ai ajouté une dernière vérification dans le cas où le dossier n'est pas modifiable et que la base de données n'existe pas.

Si elle existe déjà mais que le dossier n'est pas modifiable, ce n'est pas grave, car la base a déjà les bons droits. Cependant, si le dossier n'est pas modifiable et que je manipule l'URL, alors on peut sauter à l'étape 2 ou x et ça génère des erreurs.

```
install.php?step=2  // la page se chargera en boucle car la base n'est jamais créée
install.php?step=x  // avertos du à RainTPL qui cherche $serverConfig qui ne lui est pas assigné
```

Pas sûr que ce soit très propre comme fix, mais comme tu l'as dit, une refonte de cette page serait certainement mieux.
