### PR TITLE
Fix several version displays

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -37,21 +37,8 @@ function initDDb(&$db, &$settings, &$tpl, &$user, &$publicFeed=false, $rss=false
 
     $tpl->assign( "settings", $settings );
 
-    $publicFeed = false;
-    if($rss && isset($_GET['key']) && $_GET['key'] == $settings['appKey']) {
-        $publicFeed = true;
-    } else {
-        $user = logUser($tpl);
-    }
-
     //check for updates
-    $version = array(
-        'current' => DDB_VERSION,
-        'next' => DDB_VERSION,
-        'last' => DDB_VERSION,
-        'lastCheck' => null,
-    );
-    if(isset($user['role']) && $user['role'] == 'admin') {
+    // if(isset($user['role']) && $user['role'] == 'admin') {
         try {
             $qry = $db->prepare(
                 'SELECT * FROM ddb_version'
@@ -65,7 +52,7 @@ function initDDb(&$db, &$settings, &$tpl, &$user, &$publicFeed=false, $rss=false
                 'next' => DDB_VERSION,
                 'last' => DDB_VERSION,
                 'lastCheck' => null,
-                'mustUdpate' => false,
+                'mustUpdate' => false,
             );
 
             //create it
@@ -78,9 +65,16 @@ function initDDb(&$db, &$settings, &$tpl, &$user, &$publicFeed=false, $rss=false
         if(is_null($version['lastCheck']) || strtotime('now') > strtotime($version['lastCheck'].'+1 week')) {
             checkForUpdates();
         }
+    // }
+    $tpl->assign( "version", $version );
+
+    $publicFeed = false;
+    if($rss && isset($_GET['key']) && $_GET['key'] == $settings['appKey']) {
+        $publicFeed = true;
+    } else {
+        $user = logUser($tpl);
     }
 
-    $tpl->assign( "version", $version );
 }
 
 function setRainTpl($tplDir = '', $tplCache = '') {

--- a/install.php
+++ b/install.php
@@ -203,14 +203,23 @@ QUERY;
 //STEP 2: ask settings
 if(!file_exists("database.sqlite") && isset($_GET['step']) && intval($_GET['step']) == 2) {
     $step = 2;
-    
+
 //STEP 1: check server configuration
 } elseif(!file_exists("database.sqlite") && ((!isset($_GET['step']) || intval($_GET['step']) == 1))) {
     $step = 1;
-    
+
     $tpl->assign( "serverConfig", $serverConfig );
-    
+
 }
+
+$version = array(
+    'current' => DDB_VERSION,
+    'next' => DDB_VERSION,
+    'last' => DDB_VERSION,
+    'lastCheck' => null,
+    'mustUpdate' => false,
+);
+$tpl->assign( "version", $version );
 
 $tpl->assign( "noLogout", true );   //no DDb command button
 $tpl->assign( "step", $step );


### PR DESCRIPTION
A long time without new patch :)

I fixed several errors with the version display. On installation and login pages, in the footer, there was a warning due to a non existing key `mustUpdate`.

On the configuration page, there was not the last time we checked for a new version as it was always set to `null`.

Now, it works :)
